### PR TITLE
Boundary Conditions for Linear Advection

### DIFF
--- a/examples/linear_constant_advection.m
+++ b/examples/linear_constant_advection.m
@@ -29,7 +29,7 @@ I_TI('DT') = dt;
 I_TI('num_steps') = num_steps;
 
 I_Tech('device') = 1;
-I_Tech('REAL') = 'double'; % float
+I_Tech('REAL') = 'float'; % float, double
 I_Tech('REAL4') = sprintf('%s4',I_Tech('REAL')); %Vector datatype
 
 I_BalanceLaws('NUM_CONSERVED_VARS') = 1;
@@ -44,7 +44,7 @@ else
     I_Tech('optimizations') = ' -cl-mad-enable -cl-no-signed-zeros -cl-finite-math-only';
 end
 
-I_RunOps('periodic') = 'USE_PERIODIC'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PERIODIC'
+I_RunOps('periodic') = 'NONE'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PERIODIC'
                                        % if periodic boundary conditions should be used
 I_RunOps('order') = 4;
 I_RunOps('conservation_laws') = 'linear_constant_advection';

--- a/examples/linear_variable_advection.m
+++ b/examples/linear_variable_advection.m
@@ -29,7 +29,7 @@ I_TI('DT') = dt;
 I_TI('num_steps') = num_steps;
 
 I_Tech('device') = 1;
-I_Tech('REAL') = 'double'; % float
+I_Tech('REAL') = 'float'; % float, double
 I_Tech('REAL4') = sprintf('%s4',I_Tech('REAL')); %Vector datatype
 
 I_BalanceLaws('NUM_CONSERVED_VARS') = 1;
@@ -43,7 +43,7 @@ else
     I_Tech('optimizations') = ' -cl-mad-enable -cl-no-signed-zeros -cl-finite-math-only';
 end
 
-I_RunOps('periodic') = 'USE_PERIODIC'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PERIODIC'
+I_RunOps('periodic') = 'NONE'; % 'NONE', 'USE_PERIODIC'; must be set to 'USE_PERIODIC'
                                        % if periodic boundary conditions should be used
                                        
 I_RunOps('order') = 4;

--- a/include_physics/linear_constant_advection.h
+++ b/include_physics/linear_constant_advection.h
@@ -45,7 +45,24 @@ inline void init_fields(uint ix, uint iy, uint iz, global REAL* u) {
 
 inline void add_surface_terms(REAL time, uint ix, uint iy, uint iz, global REAL *u, REAL *du_dt) {
 
-  // nothing to do in a periodic domain
+  // For periodic boundary conditions and a single block, no surface term has to be used.
+  #ifndef USE_PERIODIC
+
+    REAL um[NUM_TOTAL_VARS] = {0};
+    get_field(ix, iy, iz, 0, 0, 0, u, um);
+
+    REAL u_bound = u_boundary(ix, iy, iz, time);
+
+    // Apply the usual upwind numerical flux at the boundaries.
+    du_dt[Field_u] += + (REAL)(M_INV[0]/DX) *
+                        ((check_bound_l(ix,1) * (a_x > 0)) * (REAL)(-1) + (check_bound_xr(ix,1) * (a_x < 0)) * (REAL)(1)) * a_x * (um[Field_u] - u_bound)
+                      + (REAL)(M_INV[0]/DY) *
+                        ((check_bound_l(iy,1) * (a_y > 0)) * (REAL)(-1) + (check_bound_yr(iy,1) * (a_y < 0)) * (REAL)(1)) * a_y * (um[Field_u] - u_bound)
+                      + (REAL)(M_INV[0]/DZ) *
+                        ((check_bound_l(iz,1) * (a_z > 0)) * (REAL)(-1) + (check_bound_zr(iz,1) * (a_z < 0)) * (REAL)(1)) * a_z * (um[Field_u] - u_bound);
+
+  #endif // USE_PERIODIC
+
   return;
 }
 
@@ -65,10 +82,9 @@ inline void compute_auxiliary_variables(REAL time, uint ix, uint iy, uint iz, gl
 
 inline void analytical_solution(uint ix, uint iy, uint iz, global REAL *u, REAL time) {
 
-	REAL u_ana =  u_analytical(ix, iy, iz, time);
+  REAL u_ana =  u_analytical(ix, iy, iz, time);
 
-	set_field_component(ix, iy, iz, Field_u, u, u_ana);
-	
+  set_field_component(ix, iy, iz, Field_u, u, u_ana);
 }
 
 

--- a/include_testcases/linear_constant_advection_donut.h
+++ b/include_testcases/linear_constant_advection_donut.h
@@ -1,34 +1,32 @@
 // This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license.
 
 // velocity coefficients a_i
-#define a_x 0.0
+#define a_x 1.0
 #define a_y 0.0
-#define a_z 2.0
+#define a_z 0.0
 
 /*
 Analytical solution. It is used to calculate the numerical error and related quantities.
 */
 inline REAL u_analytical(uint ix, uint iy, uint iz, REAL time) {
 
-	REAL x = (REAL)XMIN + ix*(REAL)DX;
-	REAL y = (REAL)YMIN + iy*(REAL)DY;
-	REAL z = (REAL)ZMIN + iz*(REAL)DZ;
+  // Coordinates of (ix,iy,iz)
+  REAL x = (REAL)XMIN + ix*(REAL)DX;
+  REAL y = (REAL)YMIN + iy*(REAL)DY;
+  REAL z = (REAL)ZMIN + iz*(REAL)DZ;
 
-	REAL s = 0;
-  	REAL c = 1;
+  // The solution is u(t,x) = u_0(x - a*t).
+  REAL dx = -time*a_x;
+  REAL dy = -time*a_y;
+  REAL dz = -time*a_z;
 
-	REAL xx = c*x + s*y;
-	REAL yy = -s*x + c*y;
-	REAL zz = z;
+  // A periodic solution is desired.
+  // Note: fmod(x, y) seems to return a value in [-y,y] (depending on the sign of x) but we want to have a value in [0,y].
+  REAL xx = fmod(x + dx - (REAL)XMIN, (REAL)(XMAX - XMIN)); xx = xx + (xx < 0) * (REAL)(XMAX - XMIN) + (REAL)XMIN;
+  REAL yy = fmod(y + dy - (REAL)YMIN, (REAL)(YMAX - YMIN)); yy = yy + (yy < 0) * (REAL)(YMAX - YMIN) + (REAL)YMIN;
+  REAL zz = fmod(z + dz - (REAL)ZMIN, (REAL)(ZMAX - ZMIN)); zz = zz + (zz < 0) * (REAL)(ZMAX - ZMIN) + (REAL)ZMIN;
 
-	REAL dx = -(REAL)0.5 + time*a_x;
-	REAL dy =  time*a_y;
-
-	REAL fac = exp(-20*((xx+dx)*(xx+dx) + (yy+dy)*(yy+dy)));
-	REAL Bx0 = -4*(yy+dy)*fac;
-	REAL By0 = (4*(xx+dx))*fac;
-
-	return (REAL) sqrt((c*Bx0-s*By0)*(c*Bx0-s*By0) + (s*Bx0+c*By0)*(s*Bx0+c*By0));
+  return exp(-20*((xx+0.5)*(xx+0.5) + yy*yy + zz*zz));
 }
 
 /*
@@ -36,5 +34,13 @@ Initial condition.
 */
 inline REAL u_init(uint ix, uint iy, uint iz) {
 
-	return u_analytical(ix, iy, iz, (REAL)0);
+  return u_analytical(ix, iy, iz, (REAL)0);
+}
+
+/*
+Boundary condition.
+*/
+inline REAL u_boundary(uint ix, uint iy, uint iz, REAL time) {
+
+  return u_analytical(ix, iy, iz, time);
 }

--- a/include_testcases/linear_variable_advection_rotation_2D.h
+++ b/include_testcases/linear_variable_advection_rotation_2D.h
@@ -5,22 +5,22 @@ Analytical solution. It is used to calculate the numerical error and related qua
 */
 inline REAL u_analytical(uint ix, uint iy, uint iz, REAL time) {
 
-	REAL x = (REAL)XMIN + ix*(REAL)DX;
-	REAL y = (REAL)YMIN + iy*(REAL)DY;
-	REAL z = (REAL)ZMIN + iz*(REAL)DZ;
+  REAL x = (REAL)XMIN + ix*(REAL)DX;
+  REAL y = (REAL)YMIN + iy*(REAL)DY;
+  REAL z = (REAL)ZMIN + iz*(REAL)DZ;
 
-	REAL s = sin(time);
+  REAL s = sin(time);
   REAL c = cos(time);
 
-	REAL xx = c*x + s*y;
-	REAL yy = -s*x + c*y;
-	REAL zz = z;
+  REAL xx = c*x + s*y;
+  REAL yy = -s*x + c*y;
+  REAL zz = z;
 
-	REAL fac = exp(-20*((xx-(REAL)(0.5))*(xx-(REAL)(0.5)) + yy*yy));
-	REAL Bx0 = -4*yy*fac;
-	REAL By0 = (4*xx-2)*fac;
+  REAL fac = exp(-20*((xx-(REAL)(0.5))*(xx-(REAL)(0.5)) + yy*yy));
+  REAL Bx0 = -4*yy*fac;
+  REAL By0 = (4*xx-2)*fac;
 
-	return (REAL) sqrt((c*Bx0-s*By0)*(c*Bx0-s*By0) + (s*Bx0+c*By0)*(s*Bx0+c*By0));
+  return (REAL) sqrt((c*Bx0-s*By0)*(c*Bx0-s*By0) + (s*Bx0+c*By0)*(s*Bx0+c*By0));
 }
 
 /*
@@ -28,5 +28,13 @@ Initial condition of the magnetic field.
 */
 inline REAL u_init(uint ix, uint iy, uint iz) {
 
-	return u_analytical(ix, iy, iz, (REAL)0);
+  return u_analytical(ix, iy, iz, (REAL)0);
+}
+
+/*
+Boundary condition.
+*/
+inline REAL u_boundary(uint ix, uint iy, uint iz, REAL time) {
+
+  return u_analytical(ix, iy, iz, time);
 }


### PR DESCRIPTION
The computation of the analytical solution for `linear_constant_advection` has been erroneous before. I have simplified the initial condition there and have added boundary conditions for both linear advection equations using the usual upwind numerical flux at the boundaries.

As a minor change, indentations using tabs have been replaced by spaces in the changed files. We might want to decide to use a common style everywhere.